### PR TITLE
Bug fixes. New features. Fixes #2 and #3.

### DIFF
--- a/FF5PR.OriginalATB/.editorconfig
+++ b/FF5PR.OriginalATB/.editorconfig
@@ -1,0 +1,7 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# Set 2-space indentation for all .csproj files
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/FF5PR.OriginalATB/Extensions.cs
+++ b/FF5PR.OriginalATB/Extensions.cs
@@ -3,6 +3,8 @@ using Last.Data.Master;
 using Last.Data.User;
 using Last.Management;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace FF5PR.OriginalATB
@@ -15,6 +17,14 @@ namespace FF5PR.OriginalATB
         public const int ATBMinOriginal = 1;
         public const int ATBMaxOriginal = 255;
 
+        public const int ATBCalcCoefficient = 64;
+        public const float ATBCalcBossEnemyCoefficient = 0.90f;
+
+        /// <summary>
+        /// Accounts for realtime ATB filling differences between Original (0-128 and PR (0-100)
+        /// </summary>
+        public const float ATBGuageRescalingFactor = 0.78125f;
+
         /// <summary>
         /// Calculate the minimum ATB value using the original FFV ATB formula rescaled to the new ATB system.
         /// </summary>
@@ -26,7 +36,7 @@ namespace FF5PR.OriginalATB
             var agi = battleUnitData.BattleUnitDataInfo.Parameter.ConfirmedAgility();
             var weight = battleUnitData.BattleUnitDataInfo.Parameter.ConfirmedWeight();
             //As far as I know, this is always 0.5 when slow 2.0 when hasted and 1.0 otherwise.
-            var timeMagnification = Plugin.Config.ATBFormula.Value == ATBFormula.Original ? battleUnitData.timeMagnification : 1f;
+            var timeMagnification = Plugin.Config.ATBFormula.Value == ATBFormula.Original ? battleUnitData.timeMagnification : 1.0f;
 
             //Plugin.Log.LogInfo($"Calculating MinATB for {battleUnitData.GetUnitName()}:");
             //Plugin.Log.LogInfo($"Inputs: agi={agi}, weight={weight}, mult={timeMagnification}, state={preeMptiveState}");
@@ -60,6 +70,108 @@ namespace FF5PR.OriginalATB
             return atbMinFloat;
         }
 
+        public static float CalcUnitSpeedCoefficient(this BattleUnitData battleUnitData)
+        {
+            var agi = battleUnitData.BattleUnitDataInfo.Parameter.ConfirmedAgility();
+            var weight = battleUnitData.BattleUnitDataInfo.Parameter.ConfirmedWeight();
+            var speedCoeff = (float)(agi - weight) / ATBCalcCoefficient + 1.0f;
+            if(battleUnitData.GetMonster() is Monster monsterData && monsterData.IsBoss())
+            {
+                speedCoeff *= ATBCalcBossEnemyCoefficient;
+            }
+
+            return speedCoeff;
+        }
+
+        /// <summary>
+        /// Calculates ATB Coefficient for given <paramref name="battleUnitData"/>.
+        /// Should give (almost) the same value as <see cref="BattleProgressATBFF0.ATBCalc(BattleUnitData)"/> when multiplied by <see cref="Time.deltaTime"/>.
+        /// Note: you wont get the exact same value since floating point math is sensitive to order of operations for rounding error.
+        ///  Use 
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <returns></returns>
+        public static float CalcATBFF0Coefficient(this BattleUnitData battleUnitData) =>
+            BattleProgressATBFF0.UpdateFPSATB * battleUnitData.CalcUnitSpeedCoefficient() * BattlePlugManager.Instance().ATBSpeed * battleUnitData.timeMagnification;
+
+        /// <summary>
+        /// Should exactly match the value returned by <see cref="BattleProgressATBFF0.ATBCalc(BattleUnitData)"/> for the same <see cref="Time.deltaTime"/>.
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <param name="deltaTime"></param>
+        /// <returns></returns>
+        public static float CalcATBFF0ForDelta(this BattleUnitData battleUnitData, float deltaTime) =>
+            deltaTime * BattleProgressATBFF0.UpdateFPSATB * battleUnitData.CalcUnitSpeedCoefficient() * BattlePlugManager.Instance().ATBSpeed * battleUnitData.timeMagnification;
+
+        /// <summary>
+        /// Should exactly match the value returned by <see cref="BattleProgressATBFF0.ATBCalc(BattleUnitData)"/>.
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <returns></returns>
+        public static float CalcATBFF0ForDelta(this BattleUnitData battleUnitData) => CalcATBFF0ForDelta(battleUnitData, Time.deltaTime);
+
+        /// <summary>
+        /// Calculate <paramref name="battleUnitData"/> ATB Delta for a given <paramref name="deltaTime"/> and <paramref name="atbFormula"/>.
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <param name="deltaTime"></param>
+        /// <param name="atbFormula"></param>
+        /// <returns></returns>
+        public static float CalcATBForDelta(this BattleUnitData battleUnitData, float deltaTime, ATBFormula atbFormula) => atbFormula switch
+        {
+            ATBFormula.Original => deltaTime * BattleProgressATBFF0.UpdateFPSATB * BattlePlugManager.Instance().ATBSpeed * ATBGuageRescalingFactor,
+            ATBFormula.OriginalFillRate => deltaTime * BattleProgressATBFF0.UpdateFPSATB * BattlePlugManager.Instance().ATBSpeed * battleUnitData.timeMagnification * ATBGuageRescalingFactor,
+            ATBFormula.PixelRemaster => deltaTime * BattleProgressATBFF0.UpdateFPSATB * battleUnitData.CalcUnitSpeedCoefficient() * BattlePlugManager.Instance().ATBSpeed * battleUnitData.timeMagnification,
+            _ => 0.0f
+        };
+
+        /// <summary>
+        /// Calculate <paramref name="battleUnitData"/> ATB Delta for a given <paramref name="deltaTime"/> using <see cref="ModConfiguration.ATBFormula"/>.
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <param name="deltaTime"></param>
+        /// <returns></returns>
+        public static float CalcATBForDelta(this BattleUnitData battleUnitData, float deltaTime) => CalcATBForDelta(battleUnitData, deltaTime, Plugin.Config.ATBFormula.Value);
+
+        /// <summary>
+        /// Calculate <paramref name="battleUnitData"/> ATB Delta using <see cref="Time.deltaTime"/> and <see cref="ModConfiguration.ATBFormula"/>.
+        /// </summary>
+        /// <param name="battleUnitData"></param>
+        /// <returns></returns>
+        public static float CalcATBForDelta(this BattleUnitData battleUnitData) => CalcATBForDelta(battleUnitData, Time.deltaTime, Plugin.Config.ATBFormula.Value);
+
+        /// <summary>
+        /// Calculates the delta time needed for the <paramref name="battleUnitData"/> to get to their next turn.
+        /// </summary>
+        /// <param name="battleUnitData">Unit to calculate ATB for.</param>
+        /// <param name="guageValue">Unit's current ATB Guage value.</param>
+        /// <param name="atbFormula"><see cref="ATBFormula"/> to use.</param>
+        /// <returns></returns>
+        public static float CalcDeltaToNextTurn(this BattleUnitData battleUnitData, float guageValue, ATBFormula atbFormula)
+        {
+            //Check if unit already has their turn.
+            if(guageValue >= BattleProgressATB.MaxATBGauge)
+            {
+                return 0.0f;
+            }
+
+            var remainingGuage = BattleProgressATB.MaxATBGauge - guageValue;
+
+            return atbFormula switch
+            {
+                ATBFormula.Original => remainingGuage / (BattleProgressATBFF0.UpdateFPSATB * BattlePlugManager.Instance().ATBSpeed),
+                ATBFormula.OriginalFillRate => remainingGuage / (BattleProgressATBFF0.UpdateFPSATB * BattlePlugManager.Instance().ATBSpeed * battleUnitData.timeMagnification),
+                ATBFormula.PixelRemaster => remainingGuage / battleUnitData.CalcATBFF0Coefficient(),
+                _ => 0.0f
+            };
+        }
+
+        public static float CalcDeltaToNextTurn(this BattleUnitData battleUnitData, float guageValue) => CalcDeltaToNextTurn(battleUnitData, guageValue, Plugin.Config.ATBFormula.Value);
+
+        public static float CalcDeltaToNextTurn(this KeyValuePair<BattleUnitData, float> pair) => CalcDeltaToNextTurn(pair.Key, pair.Value);
+
+        public static float CalcDeltaToNextTurn(this KeyValuePair<BattleUnitData, float> pair, ATBFormula atbFormula) => CalcDeltaToNextTurn(pair.Key, pair.Value, atbFormula);
+
         private static int CalcPreeMptivePenalty(BattleUnitData battleUnitData, BattlePopPlug.PreeMptiveState preeMptiveState) => preeMptiveState switch
         {
             BattlePopPlug.PreeMptiveState.BackAttack => battleUnitData.GetOwnedCharacterData() is not null ? BackAttackPenalty : 0,
@@ -87,53 +199,21 @@ namespace FF5PR.OriginalATB
 
         public static void AdvanceToNextTurn(this BattleProgressATB battleProgressATB)
         {
-            bool applyTimeMag = Plugin.Config.ATBFormula.Value != ATBFormula.Original;
-            var atbToNextTurn = battleProgressATB.CalcATBToNextTurn(applyTimeMag);
+            var atbFormula = Plugin.Config.ATBFormula.Value;
+            var guageStatusDictionary = battleProgressATB.gaugeStatusDictionary.ToManaged();
+            var minDeltaToNext = guageStatusDictionary.Min(x => x.CalcDeltaToNextTurn(atbFormula));
 
-            //Dont advance if anyone's turn is already up.
-            if(atbToNextTurn <= 0)
-            {
+            if(minDeltaToNext <= 0.0f)
+            { 
                 return;
             }
 
-            if (Plugin.Config.ATBFormula.Value != ATBFormula.PixelRemaster)
+            //Just add the calculated ATB to next turn to everyone's guage
+            foreach ((var unitData, var guageValue) in battleProgressATB.gaugeStatusDictionary.ToManaged())
             {
-                //Just add the calculated ATB to next turn to everyone's guage
-                foreach ((var unitData, var guageValue) in battleProgressATB.gaugeStatusDictionary.ToManaged())
-                {
-                    battleProgressATB.ChangeATBGaugeByUnitData(unitData, guageValue + atbToNextTurn);
-                }
-                //Plugin.Log.LogInfo($"AdvanceToNextTurn incremented all ATBs by {atbToNextTurn}.");
+                var guageDelta = unitData.CalcATBForDelta(minDeltaToNext, atbFormula);
+                battleProgressATB.ChangeATBGaugeByUnitData(unitData, guageValue + guageDelta);
             }
-            //Since I havent properly reverse engineered the PR CalcATB formula, I have to simulate it with iterative calls to CalcATB until a unit gets their turn.
-            //but don't run the iteration if deltaTime is zero or we will enter an infinite loop.
-            else if (Time.deltaTime > 0f)
-            {
-                bool advancingATB = true;
-                //Set an upper bound on the number of iteration in case something unexpected happens and ATBs are not being incremented.
-                int loopCount = 0;
-
-                for (; advancingATB && loopCount < 1000; loopCount++ )
-                {
-                    foreach ((var unitData, var guageValue) in battleProgressATB.gaugeStatusDictionary.ToManaged())
-                    {
-                        var newValue = guageValue + battleProgressATB.ATBCalc(unitData);
-                        battleProgressATB.ChangeATBGaugeByUnitData(unitData, newValue);
-
-                        if (newValue >= BattleProgressATB.MaxATBGauge)
-                        {
-                            advancingATB = false;
-                        }
-                    }
-                }
-                Plugin.Log.LogInfo($"AdvanceToNextTurn Completed in {loopCount} iterations.");
-            }
-            else if (Time.deltaTime <= 0f)
-            {
-                Plugin.Log.LogInfo($"AdvanceToNextTurn cannot advance because deltaTime={Time.deltaTime}");
-            }
-
-
 
         }
 

--- a/FF5PR.OriginalATB/FF5PR.OriginalATB.csproj
+++ b/FF5PR.OriginalATB/FF5PR.OriginalATB.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>FF5PR.OriginalATB</AssemblyName>
     <Product>FF5PR.OriginalATB</Product>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -32,7 +32,7 @@
     <DebugType>None</DebugType>
     <OutputPath>publish\bin\BepInEx\plugins\$(AssemblyName)\</OutputPath>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="publish\**" />
     <EmbeddedResource Remove="publish\**" />
@@ -49,19 +49,29 @@
     <None Include="..\README.md" Link="README.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="C:\Repos\FF5PR.OriginalATB\FF5PR.OriginalATB\.editorconfig" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.697" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" IncludeAssets="compile" />
+
+  </ItemGroup>
+
+  <!-- Publicize Assembly-CSharp.dll -->
+  <ItemGroup>
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3" PrivateAssets="all" />
+    <Reference Include="$(GamePath)\BepInEx\interop\Assembly-CSharp.dll" Publicize="true">
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <!--<Reference Include="Assembly-CSharp">
       <HintPath>$(GamePath)\BepInEx\interop\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
-    </Reference>
+    </Reference>-->
     <Reference Include="Il2Cppmscorlib">
       <HintPath>$(GamePath)\BepInEx\interop\Il2Cppmscorlib.dll</HintPath>
       <Private>False</Private>
@@ -118,10 +128,14 @@
 
 
   <Target Name="ZipOutputPath" AfterTargets="Build" Condition="'$(Configuration)' == 'PublishZip'">
-    <ZipDirectory
-        SourceDirectory="publish\bin"
-        DestinationFile="publish\$(AssemblyName).$(Version).zip"
-        Overwrite="true"/>
+    <ZipDirectory SourceDirectory="publish\bin" DestinationFile="publish\$(AssemblyName).$(Version).zip" Overwrite="true" />
   </Target>
-  
+
+  <Target Name="DebugOutput" BeforeTargets="Compile">
+    <Message Text="Gamepath: $(GamePath)" Importance="high" />
+  </Target>
+
+  <ItemGroup>
+    <EditorConfigFiles Remove="C:\Repos\FF5PR.OriginalATB\FF5PR.OriginalATB\.editorconfig" />
+  </ItemGroup>
 </Project>

--- a/FF5PR.OriginalATB/GameDetection.cs
+++ b/FF5PR.OriginalATB/GameDetection.cs
@@ -30,42 +30,25 @@ public class GameDetection
         private set => _version = value;
     }
 
-    private static GameVersion GetGameVersion()
+    private static GameVersion GetGameVersion() => GetProductName() switch
     {
-        switch (GetProductName())
+        "FINAL FANTASY" => GameVersion.FF1,
+        "FINAL FANTASY II" => GameVersion.FF2,
+        "FINAL FANTASY III" => GameVersion.FF3,
+        "FINAL FANTASY IV" => GameVersion.FF4,
+        "FINAL FANTASY V" => GameVersion.FF5,
+        "FINAL FANTASY VI" => GameVersion.FF6,
+        _ => GetModuleFileName() switch
         {
-            case "FINAL FANTASY":
-                return GameVersion.FF1;
-            case "FINAL FANTASY II":
-                return GameVersion.FF2;
-            case "FINAL FANTASY III":
-                return GameVersion.FF3;
-            case "FINAL FANTASY IV":
-                return GameVersion.FF4;
-            case "FINAL FANTASY V":
-                return GameVersion.FF5;
-            case "FINAL FANTASY VI":
-                return GameVersion.FF6;
-        }
-
-        switch (GetModuleFileName())
-        {
-            case "FINAL FANTASY":
-                return GameVersion.FF1;
-            case "FINAL FANTASY II":
-                return GameVersion.FF2;
-            case "FINAL FANTASY III":
-                return GameVersion.FF3;
-            case "FINAL FANTASY IV":
-                return GameVersion.FF4;
-            case "FINAL FANTASY V":
-                return GameVersion.FF5;
-            case "FINAL FANTASY VI":
-                return GameVersion.FF6;
-        }
-
-        return GameVersion.Unknown;
-    }
+            "FINAL FANTASY" => GameVersion.FF1,
+            "FINAL FANTASY II" => GameVersion.FF2,
+            "FINAL FANTASY III" => GameVersion.FF3,
+            "FINAL FANTASY IV" => GameVersion.FF4,
+            "FINAL FANTASY V" => GameVersion.FF5,
+            "FINAL FANTASY VI" => GameVersion.FF6,
+            _ => GameVersion.Unknown,
+        },
+    };
 
     private static string GetProductName()
     {
@@ -93,6 +76,6 @@ public class GameDetection
             return input;
         }
 
-        return input.Substring(0, nullCharIndex);
+        return input[..nullCharIndex];
     }
 }

--- a/FF5PR.OriginalATB/ModComponent.cs
+++ b/FF5PR.OriginalATB/ModComponent.cs
@@ -4,6 +4,7 @@ using System;
 using Il2CppInterop.Runtime.Injection;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using Last.Battle;
 
 namespace FF5PR.OriginalATB;
 
@@ -50,6 +51,4 @@ public sealed class ModComponent(IntPtr ptr) : MonoBehaviour(ptr)
             Plugin.Log.LogError($"[{nameof(ModComponent)}].{nameof(Awake)}(): {e}");
         }
     }
-
-
 }

--- a/FF5PR.OriginalATB/ModConfiguration.cs
+++ b/FF5PR.OriginalATB/ModConfiguration.cs
@@ -13,13 +13,34 @@ public enum ATBFormula
     PixelRemaster,
 }
 
-public sealed class ModConfiguration
+public enum AbilityBehavior
 {
-    private ConfigFile _config;
+
+    Original = 0,
+    PixelRemaster,
+}
+
+public sealed class ModConfiguration(ConfigFile config)
+{
+    //ATB
     public ConfigEntry<ATBFormula> ATBFormula;
     public ConfigEntry<bool> AdvanceFirstTurn;
     public ConfigEntry<bool> MonsterAgiVariance;
 
+    //Ability
+    public ConfigEntry<bool> SingHasteSlow;
+    public ConfigEntry<AbilityBehavior> SingDuration;
+    public ConfigEntry<AbilityBehavior> JumpDuration;
+    public ConfigEntry<AbilityBehavior> FocusDuration;
+    public ConfigEntry<AbilityBehavior> IainukiDuration;
+    public ConfigEntry<AbilityBehavior> AimDuration;
+    public ConfigEntry<AbilityBehavior> CheckDuration;
+    public ConfigEntry<AbilityBehavior> ScanDuration;
+    public ConfigEntry<AbilityBehavior> RecoverDuration;
+    public ConfigEntry<AbilityBehavior> ReviveDuration;
+    public ConfigEntry<AbilityBehavior> MimicDuration;
+
+    //Delay
     public ConfigEntry<bool> DelayAtTurnStart;
     public ConfigEntry<float> VerySlowDelayTime;
     public ConfigEntry<float> SlowDelayTime;
@@ -27,14 +48,9 @@ public sealed class ModConfiguration
     public ConfigEntry<float> FastDelayTime;
     public ConfigEntry<float> VeryFastDelayTime;
 
-    public ModConfiguration(ConfigFile config)
-    {
-        _config = config;
-    }
-
     public void Init()
     {
-        ATBFormula = _config.Bind(
+        ATBFormula = config.Bind(
              "ATB",
              nameof(ATBFormula),
              OriginalATB.ATBFormula.Original,
@@ -46,56 +62,173 @@ public sealed class ModConfiguration
              """
         );
 
-        MonsterAgiVariance = _config.Bind(
+        MonsterAgiVariance = config.Bind(
              "ATB",
              nameof(MonsterAgiVariance),
              true,
              "Add a random 0, +1, or -1 to monster Agility/Speed at the start of battle."
         );
 
-        AdvanceFirstTurn = _config.Bind(
+        AdvanceFirstTurn = config.Bind(
              "ATB",
              nameof(AdvanceFirstTurn),
              true,
-             "Automatically Advance ATB at the start of battle to the first turn."
+             "Automatically Advance ATB at the start of battle to the first Unit's turn."
         );
 
-        DelayAtTurnStart = _config.Bind(
+        SingHasteSlow = config.Bind(
+             "Ability",
+             nameof(SingHasteSlow),
+             true,
+             "Patch the Bard's Sing command to use slow/haste status (like the original)."
+        );
+
+        SingDuration = config.Bind(
+             "Ability",
+             nameof(SingDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Song command increase stats in _ intervals:
+              - {AbilityBehavior.Original}: 1 second
+              - {AbilityBehavior.PixelRemaster}: 1.5 second
+             """
+        );
+
+        JumpDuration = config.Bind(
+             "Ability",
+             nameof(JumpDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Jump command execute in:
+              - {AbilityBehavior.Original}: 0.33 seconds (before jump) and 2.66 seconds (in air)
+              - {AbilityBehavior.PixelRemaster}: 3.5 seconds (in air)
+             """
+        );
+
+        FocusDuration = config.Bind(
+             "Ability",
+             nameof(FocusDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Focus command execute in:
+              - {AbilityBehavior.Original}: 2 seconds
+              - {AbilityBehavior.PixelRemaster}: 3 seconds
+             """
+        );
+
+        IainukiDuration = config.Bind(
+             "Ability",
+             nameof(IainukiDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Iainuki command execute in:
+              - {AbilityBehavior.Original}: 2 seconds
+              - {AbilityBehavior.PixelRemaster}: 3 seconds
+             """
+        );
+
+        AimDuration = config.Bind(
+             "Ability",
+             nameof(AimDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Aim command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        CheckDuration = config.Bind(
+             "Ability",
+             nameof(CheckDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Check command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        ScanDuration = config.Bind(
+             "Ability",
+             nameof(ScanDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Scan command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        RecoverDuration = config.Bind(
+             "Ability",
+             nameof(RecoverDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Recover command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        ReviveDuration = config.Bind(
+             "Ability",
+             nameof(ReviveDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Revive command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        MimicDuration = config.Bind(
+             "Ability",
+             nameof(MimicDuration),
+             AbilityBehavior.Original,
+             $"""
+             Have the Mimic command execute in:
+              - {AbilityBehavior.Original}: 1/6 second
+              - {AbilityBehavior.PixelRemaster}: 1/2 second
+             """
+        );
+
+        DelayAtTurnStart = config.Bind(
              "Delay Time",
              nameof(DelayAtTurnStart),
              true,
              "Pause the ATB for a short time at the start of a turn. In the original game the duration of this delay was the only thing the battle speed setting affected."
         );
 
-        VerySlowDelayTime = _config.Bind(
+        VerySlowDelayTime = config.Bind(
              "Delay Time",
              nameof(VerySlowDelayTime),
              4f,
              "Time to delay ATB in the command window when a player gets their turn when battle speed is set to Very Slow."
         );
 
-        SlowDelayTime = _config.Bind(
+        SlowDelayTime = config.Bind(
              "Delay Time",
              nameof(SlowDelayTime),
              2f,
              "Time to delay ATB in the command window when a player gets their turn when battle speed is set to Slow."
         );
 
-        NormalDelayTime = _config.Bind(
+        NormalDelayTime = config.Bind(
              "Delay Time",
              nameof(NormalDelayTime),
              1f,
              "Time to delay ATB in the command window when a player gets their turn when battle speed is set to Normal."
         );
 
-        FastDelayTime = _config.Bind(
+        FastDelayTime = config.Bind(
              "Delay Time",
              nameof(FastDelayTime),
              0.5f,
              "Time to delay ATB in the command window when a player gets their turn when battle speed is set to Fast."
         );
 
-        VeryFastDelayTime = _config.Bind(
+        VeryFastDelayTime = config.Bind(
              "Delay Time",
              nameof(VeryFastDelayTime),
              0.25f,

--- a/FF5PR.OriginalATB/Patches/ATBFormulaPatches.cs
+++ b/FF5PR.OriginalATB/Patches/ATBFormulaPatches.cs
@@ -48,7 +48,7 @@ namespace FF5PR.OriginalATB.Patches
                 return;
             }
 
-            var condition = (Last.Defaine.ConditionType)id;
+            //var condition = (Last.Defaine.ConditionType)id;
             var currAtb = battleProgressATB.GetAtbGaugeByUnitData(battleUnitData);
             if (currAtb == 0f)
             {
@@ -59,7 +59,7 @@ namespace FF5PR.OriginalATB.Patches
         }
 
         /// <summary>
-        /// Override ATBCalc function to not depend on Agility or Weight stats or unit type.
+        /// Override ATBCalc function to account for current ATB Formula.
         /// </summary>
         /// <param name="__instance"></param>
         /// <param name="battleUnitData"></param>
@@ -67,32 +67,29 @@ namespace FF5PR.OriginalATB.Patches
         [HarmonyPostfix]
         static void ATBCalcHook(BattleProgressATBFF0 __instance, ref float __result, BattleUnitData battleUnitData)
         {
+            //var derivedResult = battleUnitData.CalcATBFF0ForDelta(Time.deltaTime);
+            //if(__result != derivedResult)
+            //{
+            //    Plugin.Log.LogInfo($"ATB Calc Mismatch: {battleUnitData.GetUnitName()}=>{__result} != {derivedResult}");
+            //}
+
+            //No need to recalculate ATB Delta for PR.
             if (Plugin.Config.ATBFormula.Value == ATBFormula.PixelRemaster)
             {
                 return;
             }
 
-            //TODO: more research into PR ATBCalc formula to see if a formula for ATBValue at 0 speed, 0 weight, 1.0 gamespeed can be deduced for a given deltaTime.
-            //TODO: Alternatively, figure out the time/ATB bar% factor from the original (I know its 16 frames per ATB chunk, but I am not sure how big that chunk is.
-            // This is my best guess at deducing the PR atbDelta formula with agi/weight factors removed.
-            var atbDelta = Time.deltaTime * __instance.ATBCalcCoefficient * BattlePlugManager.Instance().ATBSpeed;
+            __result = battleUnitData.CalcATBForDelta();
 
-            if(Plugin.Config.ATBFormula.Value == ATBFormula.OriginalFillRate)
-            {
-                //Also apply haste/slow to atbDelta.
-                atbDelta *= battleUnitData.timeMagnification;
-            }
+            //Hack to avoid trigging ATB reset after conditions are removed
+            __result = __result == 0f ? 0.01f : __result;
 
-            //Hack to avoid trigging ATB reset after conditions removed
-            atbDelta = atbDelta == 0f ? 0.01f : atbDelta;
-
-            __result = atbDelta;
             //Plugin.Log.LogInfo($"  End: {__instance.GetType().FullName}.{nameof(BattleProgressATBFF0.ATBCalc)}({battleUnitData.GetUnitName()})->{__result:F2}");
         }
 
         /// <summary>
         /// Just skip the original <see cref="BattleProgressATB.SetPreeMptive"/> (unless we are using original ATB formula).
-        /// We are reimplementing this and at a slightly later time in the battle init sequence.
+        /// We are reimplementing this and at a slightly later time in the battle init sequence after conditions have been applied.
         /// </summary>
         /// <returns></returns>
         [HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.SetPreeMptive))]
@@ -155,7 +152,6 @@ namespace FF5PR.OriginalATB.Patches
             if (Plugin.Config.ATBFormula.Value == ATBFormula.Original
                 //and our time magnification has actually changed,
                 && __instance.timeMagnification != timeMagnification
-                //and we are ac
                 && BattlePlugManager.Instance().BattleProgress.TryCast<BattleProgressATB>() is BattleProgressATB battleProgressATB)
             {
                 var currAtb = battleProgressATB.GetAtbGaugeByUnitData(__instance);
@@ -181,6 +177,76 @@ namespace FF5PR.OriginalATB.Patches
             int agiIncrement = CommonUtility.GetRand(-1, 2);
             //Plugin.Log.LogInfo($"Adjusting {__result.GetUnitName()} Agility {__result.BattleUnitDataInfo.Parameter.BaseAgility} -> {__result.BattleUnitDataInfo.Parameter.BaseAgility + agiIncrement} ({agiIncrement:+0;-#})");
             __result.BattleUnitDataInfo.Parameter.BaseAgility += agiIncrement;
+        }
+
+        [HarmonyPatch(typeof(SongConditionFunction), nameof(SongConditionFunction.Start))]
+        [HarmonyPostfix]
+        static void OverrideSongConditionFunctionUpdateCycle(ref SongConditionFunction __instance)
+        {
+            __instance.updateCycle = Plugin.Config.SingDuration.Value == AbilityBehavior.Original ? 2 : 3;
+        }
+
+        [HarmonyPatch(typeof(SongConditionFunction), nameof(SongConditionFunction.Update))]
+        [HarmonyPrefix]
+        static void AdjustSongTimeForTimeMagnification(ref SongConditionFunction __instance)
+        {
+            //Song Condition normally increments currentTime at the rate of 2 * ATBSpeed * deltaTime.
+            //We want to correct it so that the formula becomes: 2 * ATBSpeed * deltaTime * timeMagnification.
+
+            //Bail if we dont need to make any adjustments.
+            if (__instance.currentTime >= __instance.updateCycle 
+                || __instance.BattleUnitData.timeMagnification == 1.0f
+                || BattlePlugManager.instance is not BattlePlugManager battlePlugManager)
+            {
+                return;
+            }
+
+            var atbSpeed = battlePlugManager.ATBSpeed;
+
+            //Undo the correction the update function is about to do while also applying our time-magnified version.
+            __instance.currentTime += (atbSpeed + atbSpeed) * Time.deltaTime * (__instance.BattleUnitData.timeMagnification - 1);
+        }
+
+        [HarmonyPatch(typeof(SongConditionFunction), nameof(SongConditionFunction.Update))]
+        [HarmonyPostfix]
+        static void SongConditionFunctionUpdatePost(ref SongConditionFunction __instance)
+        {
+            if (__instance.currentTime == 0.0f)
+            {
+                Plugin.Log.LogInfo($"{__instance.BattleUnitData.GetUnitName()}: Ding!");
+            }
+        }
+
+        [HarmonyPatch(typeof(BattleProgress), nameof(BattleProgress.GetChantingTime))]
+        [HarmonyPostfix]
+        static void OverrideAbilityWaitTimes(ref float __result, BattleActData battleActData)
+        {
+            __result = battleActData.abilityList.ToManaged().Select(x => x.Id).FirstOrDefault() switch
+            {
+                //Wait times should be multiplied by two to get realtime since these timers tick at double speed.
+
+                //Jump has two ability IDs (one for jumping up, the other for air time)
+                13 => Plugin.Config.JumpDuration.Value == AbilityBehavior.Original ? 2f/3f : __result,
+                607 => Plugin.Config.JumpDuration.Value == AbilityBehavior.Original ? 16f/3f : __result,
+                //Focus (also has two ability IDs but we only care about the charging one)
+                821 => Plugin.Config.FocusDuration.Value == AbilityBehavior.Original ? 4f : __result,
+                //Iainuki
+                20 => Plugin.Config.IainukiDuration.Value == AbilityBehavior.Original ? 4f : __result,
+                //Aim
+                22 => Plugin.Config.AimDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+                //Check
+                25 => Plugin.Config.CheckDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+                //Scan
+                26 => Plugin.Config.ScanDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+                //Recover
+                33 => Plugin.Config.RecoverDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+                //Revive
+                34 => Plugin.Config.ReviveDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+                //Mimic
+                44 => Plugin.Config.MimicDuration.Value == AbilityBehavior.Original ? 1f/3f : __result,
+
+                _ => __result
+            };
         }
     }
 }

--- a/FF5PR.OriginalATB/Patches/BattleATBDelayPatches.cs
+++ b/FF5PR.OriginalATB/Patches/BattleATBDelayPatches.cs
@@ -33,28 +33,32 @@ public static class BattleATBDelayPatches
     }
 
     /// <summary>
-    /// If the delay timer still has time, then just decrement the timer and skip ATB updates.
-    /// There might be other battle things which still run (condition timers?),
-    /// but the delay time is at most 4 seconds so it shouldnt be too big of a deal.
+    /// Hooks <see cref="BattleProgressATB.Update"/> to determine which updates should be skipped.
+    /// Also handles decrementing <see cref="BattleDelayState.DelayTimer"/>.
     /// </summary>
     /// <param name="__instance"></param>
-    /// <returns></returns>
-    [HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.UpdateGaugeIncrease))]
+    /// <returns>True if <see cref="BattleProgressATB.Update"/> should be skipped.</returns>
+    [HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.Update))]
     [HarmonyPrefix]
-    static bool UpdateDelayTimer(BattleProgressATB __instance)
+    static bool ShouldAllowATBUpdate(BattleProgressATB __instance)
     {
-        
-
-        if (ModComponent.Instance.CurrentBattleDelayState.IsWaiting)
+        //Allow update to continue for conditions where update wouldnt occur anyway or if delay timer is expired.
+        if(!__instance.isEnabled
+            || BattlePlugManager.instance.BattleActExection.GetStatingAct()
+            || !BattleUtility.IsStagingEnd()
+            || (SystemConfig.instance.ATBBattleType == ATBBattleType.Wait && BattleUIManager.instance.IsWaiting())
+            || BattleUIManager.instance.IsForceWaiting()
+            || !ModComponent.Instance.CurrentBattleDelayState.IsWaiting)
         {
-            //Plugin.Log.LogInfo($"Begin: {typeof(BattleProgressATB).FullName}.{nameof(BattleProgressATB.UpdateGaugeIncrease)} DelayTimer={ModComponent.Instance.CurrentBattleDelayState.DelayTimer:F4} (skipping)");
+            return true;
+        }
+        else
+        {
+            //Plugin.Log.LogInfo($"Begin: {typeof(BattleProgressATB).FullName}.{nameof(BattleProgressATB.Update)} DelayTimer={ModComponent.Instance.CurrentBattleDelayState.DelayTimer:F4} (delaying)");
             ModComponent.Instance.CurrentBattleDelayState.DelayTimer -= Time.deltaTime;
 
             return false;
         }
-
-        //Plugin.Log.LogInfo($"Begin: {typeof(BattleProgressATB).FullName}.{nameof(BattleProgressATB.UpdateGaugeIncrease)} DelayTimer={ModComponent.Instance.CurrentBattleDelayState.DelayTimer:F4} (not skipping)");
-        return true;
     }
 
     [HarmonyPatch(typeof(BattlePlugManager), nameof(BattlePlugManager.Start))]

--- a/FF5PR.OriginalATB/Patches/TestPatches.cs
+++ b/FF5PR.OriginalATB/Patches/TestPatches.cs
@@ -2,6 +2,7 @@
 using Last.Battle;
 using Last.Data.User;
 using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem.Utilities;
 
@@ -12,6 +13,14 @@ namespace FF5PR.OriginalATB.Patches
     /// </summary>
     public static class TestPatches
     {
+        //------- BattleUtility -------
+        //[HarmonyPatch(typeof(BattleUtility), nameof(BattleUtility.GetTime))]
+        //[HarmonyPrefix]
+        //static void BattleUtilityGetTimePre()
+        //{
+        //    Plugin.Log.LogInfo($"Begin: {typeof(BattleUtility).FullName}.{nameof(BattleUtility.GetTime)}");
+        //}
+
         //------- BattleProgressATBFF0 -------
         //[HarmonyPatch(typeof(BattleProgressATBFF0), nameof(BattleProgressATBFF0.Init))]
         //[HarmonyPrefix]
@@ -145,14 +154,41 @@ namespace FF5PR.OriginalATB.Patches
         //[HarmonyPrefix]
         //static void UpdateChantTimePre(BattleProgressATB __instance)
         //{
-        //    Plugin.Log.LogInfo($"Begin: {__instance.GetType().FullName}.{nameof(BattleProgressATB.UpdateChantTime)}");
+        //    //Plugin.Log.LogInfo($"Begin: {__instance.GetType().FullName}.{nameof(BattleProgressATB.UpdateChantTime)}");
+        //    var chantTimes = __instance.chantingInfo.ToManaged().Select(x => x.time.ToString("F3"));
+        //    if (chantTimes.Any())
+        //    {
+        //        Plugin.Log.LogInfo($"Times(post): {string.Join(",", chantTimes)}");
+        //    }
         //}
 
         //[HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.UpdateChantTime))]
         //[HarmonyPostfix]
         //static void UpdateChantTimePost(BattleProgressATB __instance)
         //{
-        //    Plugin.Log.LogInfo($"  End: {__instance.GetType().FullName}.{nameof(BattleProgressATB.UpdateChantTime)}");
+        //    var chantTimes = __instance.chantingInfo.ToManaged().Select(x => x.time.ToString("F3"));
+        //    if (chantTimes.Any())
+        //    {
+        //        Plugin.Log.LogInfo($"Times(post): {string.Join(",", chantTimes)}");
+        //    }
+        //    //Plugin.Log.LogInfo($"  End: {__instance.GetType().FullName}.{nameof(BattleProgressATB.UpdateChantTime)}");
+        //}
+
+        //[HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.SetActData))]
+        //[HarmonyPrefix]
+        //static void SetActDataPre(BattleProgressATB __instance, BattleActData battleActData)
+        //{
+        //    Plugin.Log.LogInfo($"Begin: {__instance.GetType().FullName}.{nameof(BattleProgressATB.SetActData)}");
+
+        //    Plugin.Log.LogInfo($"{battleActData.AttackUnitData.GetUnitName()} using Command ID: {battleActData.Command?.Id ?? -1}");
+        //    var abilityList = battleActData.abilityList.ToManaged();
+
+        //    if(abilityList is null) { return; }
+
+        //    for (int i = 0; i < abilityList.Count; i++)
+        //    {
+        //        Plugin.Log.LogInfo($"  Ability[{i}]: ID: {battleActData.abilityList[i].Id} Wait: {battleActData.abilityList[i].AbilityWait}");
+        //    }
         //}
 
         //[HarmonyPatch(typeof(BattleProgressATB), nameof(BattleProgressATB.UpdateUI))]

--- a/FF5PR.OriginalATB/Properties/launchSettings.json
+++ b/FF5PR.OriginalATB/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "FF5PR.OriginalATB": {
+      "commandName": "Project"
+    },
+    "Run FF5 PR": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramFiles(x86)%\\Steam\\steam.exe",
+      "commandLineArgs": "steam://rungameid/1173810",
+      "debugEngines": "managed,native"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This mod offers multiple options to mix and match ATB behaviors.
     - Grants a short period of time after a gets their turn to select an action.
     - Amount delayed is based on battle speed setting.
     - Happens in wait and active mode (also just like in the original).
+- Ability delay tweaks to make certain commands wait the same duration as the original:
+    - Sing: 1.5 seconds/stat up -> 1 second (also with bugfix to apply haste/slow) 
+    - Jump: 3.5 seconds -> 3 seconds
+    - Focus and Iainuki: 3 seconds -> 2 seconds
+    - Aim, Mimic and more: 1/2 sec to 1/6 sec
 
 ## Installation
 


### PR DESCRIPTION
Fix issue #2 
The biggest problem was that in original ATB mode, the ATB fill rate was significantly higher than it should have been resulting in a much larger discrepancy between ATB, and non-ATB effects. Additionally, Many non-ATB effects/ability with a delay were also taking longer than the original. I haven't done a full play-through yet, but I can already tell that things feel much better balanced after putting more effort into making sure the ATB turn times were taking the same amount of real-time as the original.
Fix issue #3
After spending some time learning how to decompile the IL2CPP portions of the game into mostly-readable C code I was able reverse engineer a bunch of key mechanics and figure out the right way skip updating all of the time-based battle effects during the delay timer.